### PR TITLE
GH-12 : [Python] Fix `invalid-return-type` error

### DIFF
--- a/python/pyarrow/interchange/column.py
+++ b/python/pyarrow/interchange/column.py
@@ -379,7 +379,7 @@ class _PyArrowColumn:
             return ColumnNullType.USE_BITMASK, 0
 
     @property
-    def null_count(self) -> int:
+    def null_count(self) -> int | None:
         """
         Number of null elements, if known.
 
@@ -390,7 +390,7 @@ class _PyArrowColumn:
         return n
 
     @property
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> None:
         """
         The metadata for the column. See `DataFrame.metadata` for more details.
         """
@@ -466,7 +466,7 @@ class _PyArrowColumn:
 
     def _get_data_buffer(
         self,
-    ) -> Tuple[_PyArrowBuffer, Any]:  # Any is for self.dtype tuple
+    ) -> Tuple[_PyArrowBuffer, Any] | None:  # Any is for self.dtype tuple
         """
         Return the buffer containing the data and the buffer's
         associated dtype.
@@ -505,7 +505,7 @@ class _PyArrowColumn:
                 "There are no missing values so "
                 "does not have a separate mask")
 
-    def _get_offsets_buffer(self) -> Tuple[_PyArrowBuffer, Any]:
+    def _get_offsets_buffer(self) -> Tuple[_PyArrowBuffer, Any] | None:
         """
         Return the buffer containing the offset values for variable-size binary
         data (e.g., variable-length strings) and the buffer's associated dtype.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -105,7 +105,6 @@ environment.root = [
 rules.invalid-argument-type = "ignore"
 rules.invalid-assignment = "ignore"
 rules.invalid-context-manager = "ignore"
-rules.invalid-return-type = "ignore"
 rules.invalid-type-form = "ignore"
 rules.no-matching-overload = "ignore"
 rules.non-subscriptable = "ignore"


### PR DESCRIPTION
### Rationale for this change
Part of #5.

### What changes are included in this PR?
Fixes the `invalid-return-type`. This largely fixes cases where the return type could be `None`.

### Are these changes tested?
Yes, locally, type checking passes.

### Are there any user-facing changes?
No.